### PR TITLE
Remove lint groups TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,6 @@ Things that still need work or aren't even included in the text, yet:
 1. Difference between 'workspace level' and 'individual packages'?
 1. Check if .toml syntax in examples is correct
 1. In general expand the Pros/Cons of the configuration file section
-1. What about lint groups? Rustc now also has the `cargo` lint group as well as the
-   `rust_2018_ideoms` and `rust_2018_compatibilty` lint groups.
 1. How does precedence work? Can packages override workspaces, or the other way around? Or maybe based on strictness (workspaces can make lints more restrictive, not less)?
 1. How much of an issue is errors for unknown lints? My feeling is that it
    should be OK, but it does set a floor for the minimum supported rustc for


### PR DESCRIPTION
lint groups work the same as lints, when they are passed to rustc.